### PR TITLE
Python and Bower requirement files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+elasticsearch==2.2.0
+Flask==0.10.1
+html5lib==0.9999999
+httplib2==0.9.2
+isodate==0.5.4
+itsdangerous==0.24
+Jinja2==2.8
+keepalive==0.5
+MarkupSafe==0.23
+pyparsing==2.1.0
+rdflib==4.2.1
+simplejson==3.8.1
+six==1.10.0
+SPARQLWrapper==1.7.6
+urllib3==1.14
+Werkzeug==0.11.3
+wheel==0.24.0

--- a/src/static/bower.json
+++ b/src/static/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "static",
+  "homepage": "https://github.com/beeldengeluid/divedashboard-ui",
+  "authors": [
+    "Carlos Martinez <c.martinez@esciencecenter.nl>"
+  ],
+  "description": "",
+  "main": "",
+  "moduleType": [],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": "^2.2.0",
+    "bootstrap-sass": "^3.3.6",
+    "datatables": "^1.10.11"
+  }
+}


### PR DESCRIPTION
It might be easier to use `requirements.txt` and `bower.json` files for installing dependencies via pip and bower. You can then do all dependencies as follows with `$ pip install -r requirements.txt` and `$ bower install` (instead of several pip installs and bower installs). This should make installation (and documentation) a bit easier.